### PR TITLE
fix for "--print-strings"

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -177,8 +177,11 @@ void dump_msgpack_object(msgpack_data *raw_data, cmp_object_t* object, bool prin
 void dump_msgpack_string(msgpack_data *raw_data, cmp_object_t* object, uint32_t length, bool print_strings) {
     char *str = malloc(length);
     msgpack_data_read(raw_data, str, length);
+
     if (print_strings) {
-        printf("\n\"%s\"", str);
+        fprintf(stdout, "\n\"");
+        fwrite(str, 1, length, stdout);
+        fprintf(stdout, "\"");
     }
 
     free(str);

--- a/src/dump.c
+++ b/src/dump.c
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <stdio.h>
 #include "dump.h"
 #include "cmp.h"
 


### PR DESCRIPTION
msgpack doesn't necessarily use strings that are zero-terminated. So, instead of using `printf` to print the string, I broke it out into an `fwrite` sandwiched inbetween two `fprintf`s.

I'm pretty sure there's a clever way to do this using only printf, but IMO this way is easier to read.